### PR TITLE
[Step 0] Update risk tracking to not double count pending trades

### DIFF
--- a/src/risktracker.cpp
+++ b/src/risktracker.cpp
@@ -16,6 +16,9 @@ int RiskTracker::updateRisk() {
         }
     }
     this->totalRisk += runningSum;
+
+    this->pendingTrades.clear(); // clear pending trades after updating risk
+    
     return 0;
 }
 

--- a/tst/test_traderisktracker.cpp
+++ b/tst/test_traderisktracker.cpp
@@ -28,3 +28,16 @@ TEST(TradeRiskTrackerTest, TrackerZeroTest) {
     riskTracker.updateRisk();
     EXPECT_NEAR(riskTracker.getRisk(), 0, 1e-4);
 }
+
+TEST(TradeRiskTrackerTest, TrackerRiskUpdateTest) {
+    std::vector<Trade> trackedTrades;
+    RiskTracker riskTracker(0, trackedTrades);
+    EXPECT_NEAR(riskTracker.getRisk(), 0, 1e-4);
+
+    riskTracker.addTrade(Trade(50, true, 1));
+    riskTracker.updateRisk();
+    EXPECT_NEAR(riskTracker.getRisk(), 0, 50);
+
+    riskTracker.updateRisk(); // no new trades, so risk should not change
+    EXPECT_NEAR(riskTracker.getRisk(), 0, 50); // should only update risk once
+}


### PR DESCRIPTION
**What is the purpose of this PR?**
Updated the updateRisk function to not include previously counted trades by clearing the pendingTrades vector after the function call.
**What changes did you make? Why?**
Clear pending trades vector after updating risk.
**What bugs did you find while testing?**
Trades added to pending trades are readded to total risk every time risk is updated. I decided that this behavior was not explicitly defined, and it makes more sense for each risk to only be counted once.
**What was the bug you found?**
Trades added to pending trades are still "pending" even after updating risk, so subsequent updates to risk recount all previously pending trades.
**How did you address it?**
Cleared the pending trades vector after updating risk.
**What did you struggle with?**
Finding the bug (or what I think the bug is), after finding it the fix was easy to implement.
**Is there anything you would change about this step?**
No.